### PR TITLE
bugfix: fix the condition to run the image job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
   image:
     needs: [build]
     runs-on: ubuntu-latest
-    if: contains(fromJSON('["refs/heads/main","refs/tags/v*"]'), github.ref)
+    if: contains(fromJSON('["refs/tags/v*"]'), github.ref)
     permissions: 
       contents: read
       packages: write


### PR DESCRIPTION
The changes fixes the bug related to evaluation of the condition for running the job suppose to build the docker image.